### PR TITLE
チラシ・祝電の受付停止

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,23 +113,20 @@
                 下記よりアップロードいただきますようお願いいたします。
               </p>
               <p>
-                <b>※2021年9月30日(木) 23:59 に募集を締め切らせていただきます。</b>
+                <b>※2021年9月30日(木) 23:59 に募集を締め切りました。</b>
               </p>
               <p>
-                <a href="https://docs.google.com/forms/d/12DAtO9Up4fWtPuffJGLyabLR2zyIK3_RVxZqvZ--KaM" class="btn btn-primary btn-lg btn-middle-width" style="margin: 1.5rem 0" target="_blank">
-                  チラシの受付
-                  <br>
-                  <span style="font-size: 70%">(Google アカウントでのログインが必要になります)</a>
-                </a>
+                <span class="btn btn-primary btn-lg btn-middle-width" style="margin: 1.5rem 0; background: #666;">
+                  チラシの受付は終了しました
               </p>
               <p>
                 いつもありがたく頂戴しております祝電につきましても、オンラインでの受付とさせていただきます。<br>
               </p>
               <p>
-                <b>※2021年9月30日(木) 23:59 に募集を締め切らせていただきます。</b>
+                <b>※2021年9月30日(木) 23:59 に募集を締め切りました。</b>
               </p>
               <p>
-                <a href="https://docs.google.com/forms/d/16x5gUVSlIHNqL_bgFTx_SHYPLqpVn-AA3NKBlGZdr0I" class="btn btn-primary btn-lg btn-middle-width" style="margin: 1.5rem 0" target="_blank">祝電の受付</a>
+                <span class="btn btn-primary btn-lg btn-middle-width" style="margin: 1.5rem 0; background: #666;">祝電の受付は終了しました</span>
               </p>
             </div>
             <p>※最新の情報は <a href="https://twitter.com/ngm_strings">twitter</a> でお知らせします！</p>


### PR DESCRIPTION
この後に申込しようとした人にわかりやすいよう、削除でなく終了の旨を表示するようにしました。演奏会後に削除予定です。
9/30 23:59 以降にマージします。

<img width="905" alt="スクリーンショット 2021-09-30 14 06 23" src="https://user-images.githubusercontent.com/428177/135390743-be5946cb-b3d6-4418-a100-f69095f1bbd4.png">

