### PR TITLE
"コンサート" の画像・文章の幅がまちまちになっていたのを修正

### DIFF
--- a/concert/concert-info.html
+++ b/concert/concert-info.html
@@ -68,7 +68,7 @@
               <img src="7th/7th_leaflet_rescheduled_front_w440.jpg" alt="第7回チラシ" width="220" />
             </a>
           </div>
-          <div class="col-sm">
+          <div class="col-sm flex-grow-1">
             <p>大盛況でした！</p>
             <p>ご来場ありがとうございました！</p>
             <p>日時：2021年10月3日（日）</p>
@@ -96,7 +96,7 @@
               <img src="6th/6th_leaflet_front_w440.jpg" alt="第6回チラシ" width="220" />
             </a>
           </div>
-          <div class="col-sm">
+          <div class="col-sm flex-grow-1">
             <p>大盛況でした！</p>
             <p>ご来場ありがとうございました！</p>
             <p>日時：2019年10月27日（日）</p>
@@ -125,7 +125,7 @@
               <img src="5th/s_5th.jpg" alt="第5回チラシ" width="220" />
             </a>
           </div>
-          <div class="col-sm">
+          <div class="col-sm flex-grow-1">
             <p>大盛況でした！</p>
             <p>ご来場ありがとうございました！</p>
             <p>日時：2018年10月14日（日）</p>
@@ -154,7 +154,7 @@
               <img src="4th/s_4th1.jpg" alt="第4回チラシ" width="220" />
             </a>
           </div>
-          <div class="col-sm">
+          <div class="col-sm flex-grow-1">
             <p>大盛況でした！</p>
             <p>ご来場ありがとうございました！</p>
             <p>日時：2017年10月8日（日）</p>
@@ -186,7 +186,7 @@
               <img src="3rd/s_third-front.jpg" alt="第3回チラシ" width="220" />
             </a>
           </div>
-          <div class="col-sm">
+          <div class="col-sm flex-grow-1">
             <p>大盛況でした！</p>
             <p>ご来場ありがとうございました！</p>
             <p>日時：2016年10月30日（日）</p>
@@ -206,7 +206,7 @@
               <img src="2nd/s_second-front.jpg" alt="第2回チラシ" width="220" />
             </a>
           </div>
-          <div class="col-sm">
+          <div class="col-sm flex-grow-1">
             <p>大盛況でした！</p>
             <p>ご来場ありがとうございました！</p>
             <p>日時：2015年11月22日（日）</p>
@@ -227,7 +227,7 @@
               <img src="1st/s_first-front.jpg" alt="第1回チラシ" width="220" />
             </a>
           </div>
-          <div class="col-sm">
+          <div class="col-sm flex-grow-1">
             <p>大盛況でした！</p>
             <p>ご来場ありがとうございました！</p>
             <p>日時:2014年10月19日（日）</p>

--- a/ngms.css
+++ b/ngms.css
@@ -67,6 +67,9 @@ body {
 
 .col-sm {
   margin: 5px 10px;
+}
+
+.flex-grow-1 {
   flex-grow: 1;
 }
 


### PR DESCRIPTION
f7b79545d7fc433834ef3a66b4cc1052f08e3f78 の変更の影響で "コンサート" の画像・文章の幅がまちまちになっていたのを修正しました。

Before:
<img width="1167" alt="スクリーンショット 2022-01-29 20 19 00" src="https://user-images.githubusercontent.com/428177/151659186-c2bbcd7d-6763-439b-bb39-991298f3f8b5.png">

After:
<img width="1167" alt="スクリーンショット 2022-01-29 20 27 28" src="https://user-images.githubusercontent.com/428177/151659209-8da12580-ab16-4a90-aa4f-36a7304d6b57.png">

