### PR TITLE
"コンサート" 内のリンク修正

### DIFF
--- a/concert/concert-info.html
+++ b/concert/concert-info.html
@@ -92,7 +92,7 @@
         <h3>第６回演奏会</h3>
         <div class="row">
           <div class="col-sm">
-            <a href="6th/6th_leaflet_combined.jpg.jpg">
+            <a href="6th/6th_leaflet_combined.jpg">
               <img src="6th/6th_leaflet_front_w440.jpg" alt="第6回チラシ" width="220" />
             </a>
           </div>

--- a/concert/concert-info.html
+++ b/concert/concert-info.html
@@ -84,7 +84,7 @@
             <p>マリオ64</p>
             <p>OCTOPATH TRAVELER</p>
             <p>
-              <a href="https://togetter.com/li/1422586" target="_blank">第7回演奏会Togetterまとめ</a>
+              <a href="https://togetter.com/li/1783296" target="_blank">第7回演奏会Togetterまとめ</a>
             </p>
           </div>
         </div>


### PR DESCRIPTION
"コンサート" のページについて下記2点修正しました。ご確認おねがいします！

* 第6回演奏会のチラシ画像のリンク先が誤っていた (404 になっていた) のを修正
* 第7回演奏会の togetter まとめへのリンクが、第6回のものへのリンクになっていたのを修正。
