### PR TITLE
トップページの表示を終演後のものに

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,24 +53,8 @@
         <h2>お知らせ</h2>
         <hr>
         <h3 style="font-size: 200%; margin: 0 0 0.5em 0;">第8回演奏会</h3>
-        <div class="alert alert-info" style="margin: 0 0 2rem 0">
-          <p>
-            第8回演奏会はチケット制、半分の座席数での開催になりました。コロナの状況を見て座席解放する場合は各種SNSにて再度告知いたします。<br>
-          </p>
-          <p>
-            ご来場される方は下記URLより事前にチケット申し込みをしていただくようお願いいたします。
-          </p>
-          <p>
-            <a href="https://eventregist.com/e/8thNGMS" target="_blank">https://eventregist.com/e/8thNGMS</a>
-          </p>
-        </div>
-        <div class="alert alert-info" style="margin: 0 0 2rem 0">
-          <p>
-            第8回演奏会はYouTubeでの配信を予定しています。配信URL等、最新の情報については公式 twitter アカウント <a href="https://twitter.com/ngm_strings">@ngm_strings</a> をご覧ください。
-          </p>
-          <p>
-            なお、一部の作品につきましては配信できません。ご了承ください。
-          </p>
+        <div class="alert alert-warning" style="margin: 0 0 2rem 0">
+          <p>ご来場・ご声援いただきありがとうございました！</p>
         </div>
         <div class="row">
           <div class="col-sm">
@@ -110,18 +94,6 @@
               <p>
                 <iframe class="hidden-sm" src="https://www.google.com/maps/embed?pb=!1m14!1m8!1m3!1d10524.578170202569!2d136.88561300580838!3d35.01903077857469!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x0%3A0x14b06c0579552e33!2z5p2x5rW35biC6Iq46KGT5YqH5aC0!5e0!3m2!1sja!2sjp!4v1506452286188" width="400" height="300" frameborder="0" style="border:0" allowfullscreen></iframe>
                 <iframe class="visible-sm" src="https://www.google.com/maps/embed?pb=!1m14!1m8!1m3!1d10524.578170202569!2d136.88561300580838!3d35.01903077857469!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x0%3A0x14b06c0579552e33!2z5p2x5rW35biC6Iq46KGT5YqH5aC0!5e0!3m2!1sja!2sjp!4v1506452286188" width="290" height="300" frameborder="0" style="border:0" allowfullscreen></iframe>
-              </p>
-            </div>
-            <div class="alert alert-warning" style="margin: 1em 0 2em 0;">
-              <h3>祝電・応援メッセージについて</h3>
-              <p>
-                祝電・応援メッセージの受付は終了しました。
-              </p>
-            </div>
-            <div class="alert alert-warning" style="margin: 1em 0 2em 0;">
-              <h3>チラシの挟み込みについて</h3>
-              <p>
-                チラシの挟み込みの受付は終了しました。
               </p>
             </div>
             <p>※最新の情報は <a href="https://twitter.com/ngm_strings">twitter</a> でお知らせします！</p>


### PR DESCRIPTION
第8回演奏会終演後に不要な情報の削除、終焉した旨の表示を追加しました。
終演後にマージします。
![screencapture-localhost-3000-2022-10-27-13_24_48](https://user-images.githubusercontent.com/428177/198191159-8284dbe5-5f7c-43e7-a6a5-b25a1303f600.png)
