### PR TITLE
第9回演奏会の曲目追加 (セツナ)

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,8 +70,7 @@
               <p>パワプロクンポケット13</p>
               <p>原神</p>
               <p>ポケットモンスター オメガルビー・アルファサファイア</p>
-              <p>(ほか)</p>
-              <p>曲目は随時 <a href="https://twitter.com/ngm_strings">twitter</a> で発表します。お楽しみにしてください！！</p>
+              <p>いけにえと雪のセツナ</p>
             </div>
             <div class="currentConcert-section">
               <h4 class="currentConcert-section-title">アクセス</h4>


### PR DESCRIPTION
トップページの第9回演奏会の情報に曲目 (セツナ) 追加しました。
![screencapture-localhost-3000-2023-05-27-14_31_32](https://github.com/NGM-Strings/site/assets/428177/4ba5f042-2e60-43c6-b7ea-a0635c459a37)
