### PR TITLE
トップページの表示を第9回終演後のものに

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,26 +59,9 @@
           <h2>お知らせ</h2>
           <hr />
           <h3 style="font-size: 200%; margin: 0 0 0.5em 0">第9回演奏会</h3>
-          <div class="alert alert-info" style="margin: 0 0 2rem 0">
-            <p>第9回演奏会はチケット制での開催になりました。</p>
+          <div class="alert alert-warning" style="margin: 0 0 2rem 0">
             <p>
-              ご来場される方は下記URLより事前にチケット申し込みをしていただくようお願いいたします。
-            </p>
-            <p>
-              <a href="https://t.co/yitdSVfdFt" target="_blank"
-                >https://t.co/yitdSVfdFt</a
-              >
-            </p>
-          </div>
-          <div class="alert alert-info" style="margin: 0 0 2rem 0">
-            <p>
-              チラシ挟み込みをご希望される方は、こちらのフォームに必要な情報をご記入ください。
-            </p>
-            <p>後日、当楽団担当者よりチラシ挟み込みの詳細を連絡いたします。</p>
-            <p>
-              <a href="https://forms.gle/GYHjLTz6nNg2T2KL9" target="_blank"
-                >https://forms.gle/GYHjLTz6nNg2T2KL9</a
-              >
+              第9回演奏会は終演しました！ご来場・ご声援いただきありがとうございました！
             </p>
           </div>
           <div class="row">


### PR DESCRIPTION
第9回演奏会終演後に不要な情報の削除、終演した旨の表示を追加しました!
終演後にマージしますね。
![screencapture-localhost-3000-2023-10-27-18_20_02](https://github.com/NGM-Strings/site/assets/428177/d2792195-b1fd-44dc-b539-eda72eb8aa32)
